### PR TITLE
Add location list endpoints

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -9,6 +9,7 @@ const options = {
     obj.clusters = new repos.Clusters(obj, pgp)
     obj.types = new repos.Types(obj, pgp)
     obj.locations = new repos.Locations(obj, pgp)
+    obj.locationLists = new repos.LocationLists(obj, pgp)
     obj.reviews = new repos.Reviews(obj, pgp)
     obj.users = new repos.Users(obj, pgp),
     obj.reports = new repos.Reports(obj, pgp),

--- a/db/repos/index.js
+++ b/db/repos/index.js
@@ -2,6 +2,7 @@ module.exports = {
   Clusters: require('./clusters'),
   Types: require('./types'),
   Locations: require('./locations'),
+  LocationLists: require('./locationLists'),
   Reviews: require('./reviews'),
   Users: require('./users'),
   Reports: require('./reports'),

--- a/db/repos/locationLists.js
+++ b/db/repos/locationLists.js
@@ -1,0 +1,65 @@
+const sql = require('../sql').locationLists
+
+class LocationLists {
+  constructor(db, pgp) {
+    this.db = db
+    this.pgp = pgp
+  }
+
+  addList(obj, user) {
+    const values = {
+      name: null,
+      description: null,
+      ...obj,
+      user_id: user.id
+    }
+    return this.db.one(sql.addList, values)
+  }
+
+  editList(id, obj) {
+    const values = {...obj, id: parseInt(id)}
+    return this.db.one(sql.editList, values)
+  }
+
+  showList(id) {
+    return this.db.one(sql.showList, {id: parseInt(id)})
+  }
+
+  showListWithLocations(id) {
+    return this.db.one(sql.showListWithLocations, {id: parseInt(id)})
+  }
+
+  listUserLists(user_id) {
+    return this.db.any(sql.listUserLists, {user_id: parseInt(user_id)})
+  }
+
+  listUserListsWithLocations(user_id) {
+    return this.db.any(sql.listUserListsWithLocations, {user_id: parseInt(user_id)})
+  }
+
+  deleteList(id) {
+    return this.db.none(sql.deleteList, {id: parseInt(id)})
+  }
+
+  addLocationToList(location_id, list_id) {
+    return this.db.none(
+      sql.addLocationToList,
+      {
+        location_id: parseInt(location_id),
+        list_id: parseInt(list_id)
+      }
+    )
+  }
+
+  dropLocationFromList(location_id, list_id) {
+    return this.db.none(
+      sql.dropLocationFromList,
+      {
+        location_id: parseInt(location_id),
+        list_id: parseInt(list_id)
+      }
+    )
+  }
+}
+
+module.exports = LocationLists

--- a/db/repos/locations.js
+++ b/db/repos/locations.js
@@ -1,4 +1,5 @@
 const sql = require('../sql').locations
+const { parse } = require('dotenv')
 const _ = require('../../helpers')
 const Changes = require('./changes')
 const Types = require('./types')
@@ -35,12 +36,12 @@ class Locations {
     return _.format_location(location)
   }
 
-  async show(id) {
-    const location = await this.db.one(sql.show, {id: parseInt(id)})
+  async show(id, user) {
+    const location = await this.db.one(sql.show, {id: parseInt(id), user_id: user ? user.id : null})
     return _.format_location(location)
   }
 
-  async list({ids = null, bounds = null, center = null, muni = 'true', types = null, invasive = 'false', limit = '1000', offset = '0', photo = 'false', locale = null}) {
+  async list({ids = null, bounds = null, center = null, muni = 'true', types = null, invasive = 'false', limit = '1000', offset = '0', photo = 'false', locale = null}, user) {
     if (!ids && !bounds && !center) {
       throw Error('Either ids, bounds, or center are required')
     }
@@ -64,6 +65,7 @@ class Locations {
       limit: parseInt(limit),
       offset: parseInt(offset),
       distance: {column: '', order: ''},
+      in_list: ''
     }
     if (center) {
       const point = _.parse_point(center)
@@ -75,6 +77,16 @@ class Locations {
         `,
         order: 'ORDER BY distance'
       }
+    }
+    if (user) {
+      values.in_list = `,
+      exists (
+        select 1
+        from locations_routes
+        join routes on routes.id = locations_routes.route_id
+        where routes.user_id = ${parseInt(user.id)} and locations_routes.location_id = locations.id
+      ) as in_list
+      `
     }
     if (photo === 'true') {
       return this.db.any(sql.listphoto, values)

--- a/db/sql/locationLists/addList.sql
+++ b/db/sql/locationLists/addList.sql
@@ -1,0 +1,21 @@
+insert into routes (
+  name,
+  description,
+  user_id,
+  created_at,
+  updated_at
+)
+values (
+  ${name},
+  ${description},
+  ${user_id},
+  now(),
+  now()
+)
+returning
+  id,
+  name,
+  description,
+  user_id,
+  created_at,
+  updated_at

--- a/db/sql/locationLists/addLocationToList.sql
+++ b/db/sql/locationLists/addLocationToList.sql
@@ -1,0 +1,19 @@
+insert into locations_routes (
+  location_id,
+  route_id,
+  position,
+  created_at,
+  updated_at
+)
+values (
+  ${location_id},
+  ${list_id},
+  (
+    select coalesce(max(position) + 1, 0)
+    from locations_routes
+    where route_id = ${list_id}
+  ),
+  now(),
+  now()
+)
+on conflict do nothing

--- a/db/sql/locationLists/deleteList.sql
+++ b/db/sql/locationLists/deleteList.sql
@@ -1,0 +1,2 @@
+delete from routes
+where id = ${id}

--- a/db/sql/locationLists/dropLocationFromList.sql
+++ b/db/sql/locationLists/dropLocationFromList.sql
@@ -1,0 +1,12 @@
+with dropped as (
+  delete from locations_routes
+  where
+    location_id = ${location_id} and
+    route_id = ${list_id}
+  returning position
+)
+update locations_routes
+set position = position - 1
+where
+  route_id = ${list_id} and
+  position > (select position from dropped)

--- a/db/sql/locationLists/editList.sql
+++ b/db/sql/locationLists/editList.sql
@@ -1,0 +1,18 @@
+update routes
+set (
+  name,
+  description,
+  updated_at
+) = (
+  ${name},
+  ${description},
+  now()
+)
+where id = ${id}
+returning
+  id,
+  name,
+  description,
+  user_id,
+  created_at,
+  updated_at

--- a/db/sql/locationLists/listUserLists.sql
+++ b/db/sql/locationLists/listUserLists.sql
@@ -1,0 +1,9 @@
+select
+  routes.id,
+  routes.name,
+  routes.description,
+  routes.user_id,
+  routes.created_at,
+  routes.updated_at
+from routes
+where routes.user_id = ${user_id}

--- a/db/sql/locationLists/listUserListsWithLocations.sql
+++ b/db/sql/locationLists/listUserListsWithLocations.sql
@@ -1,0 +1,31 @@
+with lists as (
+  select
+    locations_routes.route_id as id,
+    json_agg(
+      json_build_object(
+        'id', locations.id,
+        'added_at', locations_routes.created_at,
+        'lat', locations.lat,
+        'lng', locations.lng,
+        'type_ids', locations.type_ids,
+        'address', locations.address
+      )
+    order by locations_routes.position
+  ) as locations
+  from locations_routes
+  left join locations on locations.id = locations_routes.location_id
+  left join routes on routes.id = locations_routes.route_id
+  where routes.user_id = ${user_id}
+  group by locations_routes.route_id
+)
+select
+  routes.id,
+  routes.name,
+  routes.description,
+  routes.user_id,
+  routes.created_at,
+  routes.updated_at,
+  lists.locations
+from routes
+left join lists on lists.id = routes.id
+where routes.user_id = ${user_id}

--- a/db/sql/locationLists/showList.sql
+++ b/db/sql/locationLists/showList.sql
@@ -1,0 +1,9 @@
+select
+  routes.id,
+  routes.name,
+  routes.description,
+  routes.user_id,
+  routes.created_at,
+  routes.updated_at
+from routes
+where routes.id = ${id}

--- a/db/sql/locationLists/showListWithLocations.sql
+++ b/db/sql/locationLists/showListWithLocations.sql
@@ -1,0 +1,29 @@
+with lists as (
+  select
+    locations_routes.route_id as id,
+    json_agg(
+      json_build_object(
+        'id', locations.id,
+        'added_at', locations_routes.created_at,
+        'lat', locations.lat,
+        'lng', locations.lng,
+        'type_ids', locations.type_ids,
+        'address', locations.address
+      ) order by locations_routes.position
+    ) as locations
+  from locations_routes
+  left join locations on locations.id = locations_routes.location_id
+  where locations_routes.route_id = ${id}
+  group by locations_routes.route_id
+)
+select
+  routes.id,
+  routes.name,
+  routes.description,
+  routes.user_id,
+  routes.created_at,
+  routes.updated_at,
+  lists.locations
+from routes
+left join lists on lists.id = routes.id
+where routes.id = ${id}

--- a/db/sql/locations/list.sql
+++ b/db/sql/locations/list.sql
@@ -1,4 +1,9 @@
-SELECT id, lng, lat, type_ids ${distance.column:raw}
+SELECT
+  id,
+  lng,
+  lat,
+  type_ids ${distance.column:raw}
+  ${in_list:raw}
 FROM locations
 WHERE ${where:raw}
 ${distance.order:raw}

--- a/db/sql/locations/listname.sql
+++ b/db/sql/locations/listname.sql
@@ -1,16 +1,21 @@
-WITH temp AS (
-  SELECT id, lng, lat, UNNEST(type_ids) as type_ids
-  FROM locations
+WITH locations AS (
+  SELECT
+    id,
+    lng,
+    lat,
+    UNNEST(type_ids) as type_ids
+  FROM public.locations
   WHERE ${where:raw}
   LIMIT ${limit}
   OFFSET ${offset}
 )
 SELECT
-  temp.id,
-  temp.lat,
-  temp.lng,
-  ARRAY_AGG(temp.type_ids) as type_ids,
+  locations.id,
+  locations.lat,
+  locations.lng,
+  ARRAY_AGG(locations.type_ids) as type_ids,
   ARRAY_AGG(COALESCE(${names:raw})) AS type_names
-FROM temp, types
-WHERE types.id = temp.type_ids
-GROUP BY temp.id, temp.lat, temp.lng
+  ${in_list:raw}
+FROM locations, types
+WHERE types.id = locations.type_ids
+GROUP BY locations.id, locations.lat, locations.lng

--- a/db/sql/locations/listphoto.sql
+++ b/db/sql/locations/listphoto.sql
@@ -1,7 +1,11 @@
 SELECT
-  l.id, lng, lat, type_ids ${distance.column:raw},
+  locations.id,
+  lng,
+  lat,
+  type_ids ${distance.column:raw},
   j.thumb as photo
-FROM locations l
+  ${in_list:raw}
+FROM locations
   LEFT JOIN (
     SELECT DISTINCT ON (o.location_id)
       o.location_id, p.thumb
@@ -10,7 +14,7 @@ FROM locations l
     ON o.id = p.observation_id
     ORDER BY o.location_id, p.id DESC
   ) as j
-ON l.id = j.location_id
+ON locations.id = j.location_id
 WHERE ${where:raw}
 ${distance.order:raw}
 LIMIT ${limit}

--- a/db/sql/locations/show.sql
+++ b/db/sql/locations/show.sql
@@ -1,3 +1,21 @@
+WITH lists AS (
+  SELECT
+    locations_routes.location_id,
+    json_agg(
+      json_build_object(
+        'id', routes.id,
+        'name', routes.name,
+        'description', routes.description,
+        'user_id', routes.user_id,
+        'created_at', routes.created_at,
+        'updated_at', routes.updated_at
+      )
+    ) AS lists
+  FROM locations_routes
+  JOIN routes ON routes.id = locations_routes.route_id
+  WHERE routes.user_id = ${user_id} AND locations_routes.location_id = ${id}
+  GROUP BY locations_routes.location_id
+)
 SELECT
   l.id,
   l.lat,
@@ -19,8 +37,11 @@ SELECT
   l.state,
   l.country,
   l.muni,
-  l.invasive
+  l.invasive,
+  coalesce(lists.lists, '[]'::json) AS lists
 FROM locations l
 LEFT JOIN users u
   ON l.user_id = u.id
+LEFT JOIN lists
+  ON lists.location_id = l.id
 WHERE l.id = ${id}

--- a/docs/components/parameters.yml
+++ b/docs/components/parameters.yml
@@ -10,14 +10,9 @@ bounds:
     minItems: 2
     maxItems: 2
     items:
-      type: array
-      minItems: 2
-      maxItems: 2
-      items:
-        type: number
-        minimum: -180
-        maximum: 180
-    example: [[-5, -180], [5, 180]]
+      type: string
+      pattern: '^(-?\d+\.?(\d+)?),(-?\d+\.?(\d+)?)$'
+    example: ['-5,-180', '5,180']
 zoom:
   name: zoom
   description: Zoom level, where the world is divided into a 2<sup>zoom</sup> x 2<sup>zoom</sup> grid.
@@ -57,6 +52,14 @@ location_id:
   name: id
   in: path
   description: Location ID.
+  required: true
+  schema:
+    type: integer
+    minimum: 1
+location_list_id:
+  name: list_id
+  in: path
+  description: Location List ID.
   required: true
   schema:
     type: integer

--- a/docs/components/schemas.yml
+++ b/docs/components/schemas.yml
@@ -216,6 +216,10 @@ ListLocation:
             type: integer
             minimum: 1
           example: [97, 92]
+        in_list:
+          description: Whether the Location is in any of the current user's lists. Only included if the user is authenticated.
+          type: boolean
+          example: true
         distance:
           description: Distance in meters from provided centerpoint.
           type: number
@@ -313,6 +317,7 @@ Location:
         - season_start
         - season_stop
         - muni
+        - lists
       properties:
         user_id:
           description: User ID.
@@ -368,6 +373,11 @@ Location:
           type: array
           items:
             $ref: '#/Review'
+        lists:
+          description: User's lists that include the Location.
+          type: array
+          items:
+            $ref: '#/LocationList'
 LocationChange:
   title: Location change
   allOf:
@@ -446,6 +456,79 @@ LocationChange:
           minLength: 1
           nullable: true
           example: United States
+EditLocationList:
+  title: Location List (edit)
+  description: Location List properties that can be edited.
+  type: object
+  required:
+    - name
+  properties:
+    name:
+      description: Name.
+      type: string
+      minLength: 1
+      example: My favorite trees
+    description:
+      description: Description.
+      type: string
+      minLength: 1
+      nullable: true
+      example: My favorite trees in Boulder, Colorado.
+LocationList:
+  title: Location List
+  description: List of saved locations.
+  type: object
+  allOf:
+    - $ref: '#/IdField'
+    - $ref: '#/DateFields'
+    - $ref: '#/EditLocationList'
+    - type: object
+      required:
+        - name
+        - user_id
+      properties:
+        user_id:
+          description: User ID.
+          type: integer
+          nullable: false
+          minimum: 1
+          example: 1
+        locations:
+          description: Locations in the list, in order of addition or, for legacy routes, custom arbitrary order.
+          type: array
+          items:
+            $ref: '#/LocationListLocation'
+LocationListLocation:
+  title: Location List Location
+  description: Location in a Location List.
+  allOf:
+    - $ref: '#/IdField'
+    - $ref: '#/LatLngFields'
+    - type: object
+      required:
+        - lat
+        - lng
+        - type_ids
+        - added_at
+      properties:
+        type_ids:
+          description: Type IDs.
+          type: array
+          items:
+            type: integer
+            minimum: 1
+          example: [97, 92]
+        added_at:
+          description: Date and time added to list, in format YYYY-MM-DDThh:mm:ss.sssZ.
+          type: string
+          format: date-time
+          example: '2014-06-19T01:02:03.456Z'
+        address:
+          description: Address.
+          type: string
+          minLength: 1
+          nullable: true
+          example: '748 10th Street, Boulder CO 80302, USA'
 BaseReview:
   title: Review (base)
   type: object

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -52,6 +52,8 @@ tags:
     description: Types describe the plants, fungi, or other resources present at a Location.
   - name: Locations
     description: Locations describe resources at a particular position in the world.
+  - name: Location lists
+    description: User-created lists of Locations.
   - name: Reviews
     description: Reviews describe observations of, and opinions about, a Location.
   - name: Photos
@@ -74,12 +76,18 @@ paths:
     $ref: paths/imports~id.yml
   /locations:
     $ref: paths/locations.yml
+  /locations/lists:
+    $ref: paths/locations~lists.yml
+  /locations/lists/{list_id}:
+    $ref: paths/locations~lists~list_id.yml
   /locations/changes:
     $ref: paths/locations~changes.yml
   /locations/count:
     $ref: paths/locations~count.yml
   /locations/{id}:
     $ref: paths/locations~id.yml
+  /locations/{id}/lists/{list_id}:
+    $ref: paths/locations~id~lists~list_id.yml
   /locations/{id}/reviews:
     $ref: paths/locations~id~reviews.yml
   /photos:

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -52,6 +52,8 @@ tags:
     description: 'Types describe the plants, fungi, or other resources present at a Location.'
   - name: Locations
     description: Locations describe resources at a particular position in the world.
+  - name: Location lists
+    description: User-created lists of Locations.
   - name: Reviews
     description: 'Reviews describe observations of, and opinions about, a Location.'
   - name: Photos
@@ -126,6 +128,8 @@ paths:
         - Locations
       security:
         - key: []
+        - key: []
+          token: []
       parameters:
         - name: ids
           in: query
@@ -148,18 +152,11 @@ paths:
             minItems: 2
             maxItems: 2
             items:
-              type: array
-              minItems: 2
-              maxItems: 2
-              items:
-                type: number
-                minimum: -180
-                maximum: 180
+              type: string
+              pattern: '^(-?\d+\.?(\d+)?),(-?\d+\.?(\d+)?)$'
             example:
-              - - -5
-                - -180
-              - - 5
-                - 180
+              - '-5,-180'
+              - '5,180'
         - name: center
           in: query
           description: 'Center `latitude,longitude` in WGS84 decimal degrees. If provided, Locations are returned in order of increasing distance and the distance to each Location is returned. Longitude must be in the interval [-180, 180] and latitude in the interval [-90, 90].'
@@ -242,6 +239,121 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Location'
+  /locations/lists:
+    post:
+      summary: Create a new Location List.
+      tags:
+        - Location lists
+      security:
+        - key: []
+          token: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EditLocationList'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LocationList'
+    get:
+      summary: Fetch User's Location Lists.
+      tags:
+        - Location lists
+      security:
+        - key: []
+          token: []
+      parameters:
+        - name: embed
+          description: |
+            Additional information to include.
+            - locations: List locations.
+          in: query
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - locations
+            default: null
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/LocationList'
+  '/locations/lists/{list_id}':
+    get:
+      summary: Get a Location List.
+      tags:
+        - Location lists
+      security:
+        - key: []
+          token: []
+      parameters:
+        - $ref: '#/components/parameters/location_list_id'
+        - name: embed
+          description: |
+            Additional information to include.
+            - locations: List locations.
+          in: query
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - locations
+            default: null
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LocationList'
+    put:
+      summary: Edit a Location List.
+      tags:
+        - Location lists
+      security:
+        - key: []
+          token: []
+      parameters:
+        - $ref: '#/components/parameters/location_list_id'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EditLocationList'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LocationList'
+    delete:
+      summary: Delete a Location List.
+      tags:
+        - Location lists
+      security:
+        - key: []
+          token: []
+      parameters:
+        - $ref: '#/components/parameters/location_list_id'
+      responses:
+        '200':
+          description: Success
   /locations/changes:
     get:
       summary: Fetch Location changes (activity).
@@ -320,6 +432,8 @@ paths:
         - Locations
       security:
         - key: []
+        - key: []
+          token: []
       parameters:
         - $ref: '#/components/parameters/location_id'
         - name: embed
@@ -381,6 +495,33 @@ paths:
       responses:
         '204':
           description: Success (no content)
+  '/locations/{id}/lists/{list_id}':
+    post:
+      summary: Add a Location to a Location List.
+      tags:
+        - Location lists
+      security:
+        - key: []
+          token: []
+      parameters:
+        - $ref: '#/components/parameters/location_id'
+        - $ref: '#/components/parameters/location_list_id'
+      responses:
+        '204':
+          description: Success
+    delete:
+      summary: Remove a Location from a Location List.
+      tags:
+        - Location lists
+      security:
+        - key: []
+          token: []
+      parameters:
+        - $ref: '#/components/parameters/location_id'
+        - $ref: '#/components/parameters/location_list_id'
+      responses:
+        '204':
+          description: Success
   '/locations/{id}/reviews':
     get:
       summary: Fetch a Location's Reviews.
@@ -989,18 +1130,11 @@ components:
         minItems: 2
         maxItems: 2
         items:
-          type: array
-          minItems: 2
-          maxItems: 2
-          items:
-            type: number
-            minimum: -180
-            maximum: 180
+          type: string
+          pattern: '^(-?\d+\.?(\d+)?),(-?\d+\.?(\d+)?)$'
         example:
-          - - -5
-            - -180
-          - - 5
-            - 180
+          - '-5,-180'
+          - '5,180'
     zoom:
       name: zoom
       description: 'Zoom level, where the world is divided into a 2<sup>zoom</sup> x 2<sup>zoom</sup> grid.'
@@ -1040,6 +1174,14 @@ components:
       name: id
       in: path
       description: Location ID.
+      required: true
+      schema:
+        type: integer
+        minimum: 1
+    location_list_id:
+      name: list_id
+      in: path
+      description: Location List ID.
       required: true
       schema:
         type: integer
@@ -1347,6 +1489,10 @@ components:
               example:
                 - 97
                 - 92
+            in_list:
+              description: Whether the Location is in any of the current user's lists. Only included if the user is authenticated.
+              type: boolean
+              example: true
             distance:
               description: Distance in meters from provided centerpoint.
               type: number
@@ -1453,6 +1599,7 @@ components:
             - season_start
             - season_stop
             - muni
+            - lists
           properties:
             user_id:
               description: User ID.
@@ -1508,6 +1655,11 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/Review'
+            lists:
+              description: User's lists that include the Location.
+              type: array
+              items:
+                $ref: '#/components/schemas/LocationList'
     LocationChange:
       title: Location change
       allOf:
@@ -1591,6 +1743,81 @@ components:
               minLength: 1
               nullable: true
               example: United States
+    EditLocationList:
+      title: Location List (edit)
+      description: Location List properties that can be edited.
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          description: Name.
+          type: string
+          minLength: 1
+          example: My favorite trees
+        description:
+          description: Description.
+          type: string
+          minLength: 1
+          nullable: true
+          example: 'My favorite trees in Boulder, Colorado.'
+    LocationList:
+      title: Location List
+      description: List of saved locations.
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/IdField'
+        - $ref: '#/components/schemas/DateFields'
+        - $ref: '#/components/schemas/EditLocationList'
+        - type: object
+          required:
+            - name
+            - user_id
+          properties:
+            user_id:
+              description: User ID.
+              type: integer
+              nullable: false
+              minimum: 1
+              example: 1
+            locations:
+              description: 'Locations in the list, in order of addition or, for legacy routes, custom arbitrary order.'
+              type: array
+              items:
+                $ref: '#/components/schemas/LocationListLocation'
+    LocationListLocation:
+      title: Location List Location
+      description: Location in a Location List.
+      allOf:
+        - $ref: '#/components/schemas/IdField'
+        - $ref: '#/components/schemas/LatLngFields'
+        - type: object
+          required:
+            - lat
+            - lng
+            - type_ids
+            - added_at
+          properties:
+            type_ids:
+              description: Type IDs.
+              type: array
+              items:
+                type: integer
+                minimum: 1
+              example:
+                - 97
+                - 92
+            added_at:
+              description: 'Date and time added to list, in format YYYY-MM-DDThh:mm:ss.sssZ.'
+              type: string
+              format: date-time
+              example: '2014-06-19T01:02:03.456Z'
+            address:
+              description: Address.
+              type: string
+              minLength: 1
+              nullable: true
+              example: '748 10th Street, Boulder CO 80302, USA'
     BaseReview:
       title: Review (base)
       type: object

--- a/docs/paths/locations.yml
+++ b/docs/paths/locations.yml
@@ -4,6 +4,8 @@ get:
     - Locations
   security:
     - key: []
+    - key: []
+      token: []
   parameters:
     - name: ids
       in: query
@@ -26,14 +28,9 @@ get:
         minItems: 2
         maxItems: 2
         items:
-          type: array
-          minItems: 2
-          maxItems: 2
-          items:
-            type: number
-            minimum: -180
-            maximum: 180
-        example: [[-5, -180], [5, 180]]
+          type: string
+          pattern: '^(-?\d+\.?(\d+)?),(-?\d+\.?(\d+)?)$'
+        example: ['-5,-180', '5,180']
     - name: center
       in: query
       description: Center `latitude,longitude` in WGS84 decimal degrees. If provided, Locations are returned in order of increasing distance and the distance to each Location is returned. Longitude must be in the interval [-180, 180] and latitude in the interval [-90, 90].

--- a/docs/paths/locations~id.yml
+++ b/docs/paths/locations~id.yml
@@ -4,6 +4,8 @@ get:
     - Locations
   security:
     - key: []
+    - key: []
+      token: []
   parameters:
     - $ref: ../components/parameters.yml#/location_id
     - name: embed

--- a/docs/paths/locations~id~lists~list_id.yml
+++ b/docs/paths/locations~id~lists~list_id.yml
@@ -1,0 +1,26 @@
+post:
+  summary: Add a Location to a Location List.
+  tags:
+    - Location lists
+  security:
+    - key: []
+      token: []
+  parameters:
+    - $ref: '../components/parameters.yml#/location_id'
+    - $ref: '../components/parameters.yml#/location_list_id'
+  responses:
+    '204':
+      description: Success
+delete:
+  summary: Remove a Location from a Location List.
+  tags:
+    - Location lists
+  security:
+    - key: []
+      token: []
+  parameters:
+    - $ref: '../components/parameters.yml#/location_id'
+    - $ref: '../components/parameters.yml#/location_list_id'
+  responses:
+    '204':
+      description: Success

--- a/docs/paths/locations~lists.yml
+++ b/docs/paths/locations~lists.yml
@@ -1,0 +1,49 @@
+post:
+  summary: Create a new Location List.
+  tags:
+    - Location lists
+  security:
+    - key: []
+      token: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: ../components/schemas.yml#/EditLocationList
+  responses:
+    '200':
+      description: Success
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas.yml#/LocationList
+get:
+  summary: Fetch User's Location Lists.
+  tags:
+    - Location lists
+  security:
+    - key: []
+      token: []
+  parameters:
+    - name: embed
+      description: |
+        Additional information to include.
+        - locations: List locations.
+      in: query
+      explode: false
+      schema:
+        type: array
+        items:
+          type: string
+          enum: [locations]
+        default: null
+  responses:
+    '200':
+      description: Success
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: ../components/schemas.yml#/LocationList

--- a/docs/paths/locations~lists~list_id.yml
+++ b/docs/paths/locations~lists~list_id.yml
@@ -1,0 +1,62 @@
+get:
+  summary: Get a Location List.
+  tags:
+    - Location lists
+  security:
+    - key: []
+      token: []
+  parameters:
+    - $ref: '../components/parameters.yml#/location_list_id'
+    - name: embed
+      description: |
+        Additional information to include.
+        - locations: List locations.
+      in: query
+      explode: false
+      schema:
+        type: array
+        items:
+          type: string
+          enum: [locations]
+        default: null
+  responses:
+    '200':
+      description: Success
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas.yml#/LocationList
+put:
+  summary: Edit a Location List.
+  tags:
+    - Location lists
+  security:
+    - key: []
+      token: []
+  parameters:
+    - $ref: '../components/parameters.yml#/location_list_id'
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: ../components/schemas.yml#/EditLocationList
+  responses:
+    '200':
+      description: Success
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas.yml#/LocationList
+delete:
+  summary: Delete a Location List.
+  tags:
+    - Location lists
+  security:
+    - key: []
+      token: []
+  parameters:
+    - $ref: '../components/parameters.yml#/location_list_id'
+  responses:
+    '200':
+      description: Success

--- a/index.js
+++ b/index.js
@@ -97,11 +97,100 @@ get(
   req => db.types.show(req.params.id)
 )
 
+// Routes: Location lists
+post(
+  `${process.env.API_BASE}/locations/lists`,
+  middleware.authenticate('user'),
+  async (req, res) => {
+    // Require name
+    if (!req.body.name) {
+      return void res.status(400).json({error: 'Name is required'})
+    }
+    return await db.locationLists.addList(req.body, req.user)
+  }
+)
+get(
+  `${process.env.API_BASE}/locations/lists`,
+  middleware.authenticate('user'),
+  async (req) => {
+    if (req.query.embed === 'locations') {
+      return await db.locationLists.listUserListsWithLocations(req.user.id)
+    }
+    return await db.locationLists.listUserLists(req.user.id)
+  }
+)
+get(
+  `${process.env.API_BASE}/locations/lists/:id`,
+  middleware.authenticate('user'),
+  async (req) => {
+    if (req.query.embed === 'locations') {
+      return await db.locationLists.listUserListsWithLocations(req.user.id)
+    }
+    return await db.locationLists.listUserLists(req.user.id)
+  }
+)
+put(
+  `${process.env.API_BASE}/locations/lists/:id`,
+  middleware.authenticate('user'),
+  async (req, res) => {
+    // Restrict to linked user
+    const list = await db.locationLists.showList(req.params.id)
+    if (list.user_id != req.user.id) {
+      return void res.status(403).json({error: 'Insufficient permissions'})
+    }
+    // Require name
+    if (!req.body.name) {
+      return void res.status(400).json({error: 'Name is required'})
+    }
+    return await db.locationLists.editList(req.params.id, req.body)
+  }
+)
+drop(
+  `${process.env.API_BASE}/locations/lists/:id`,
+  middleware.authenticate('user'),
+  async (req, res) => {
+    // Restrict to linked user
+    const list = await db.locationLists.showList(req.params.id)
+    if (list.user_id != req.user.id) {
+      return void res.status(403).json({error: 'Insufficient permissions'})
+    }
+    await db.locationLists.deleteList(req.params.id)
+    return void res.status(204).send()
+  }
+)
+post(
+  `${process.env.API_BASE}/locations/:id/lists/:list_id`,
+  middleware.authenticate('user'),
+  async (req, res) => {
+    // Restrict to linked user
+    const list = await db.locationLists.showList(req.params.list_id)
+    if (list.user_id != req.user.id) {
+      return void res.status(403).json({error: 'Insufficient permissions'})
+    }
+    await db.locationLists.addLocationToList(req.params.id, req.params.list_id)
+    return void res.status(204).send()
+  }
+)
+drop(
+  `${process.env.API_BASE}/locations/:id/lists/:list_id`,
+  middleware.authenticate('user'),
+  async (req, res) => {
+    // Restrict to linked user
+    const list = await db.locationLists.showList(req.params.list_id)
+    if (list.user_id != req.user.id) {
+      return void res.status(403).json({error: 'Insufficient permissions'})
+    }
+    await db.locationLists.dropLocationFromList(req.params.id, req.params.list_id)
+    return void res.status(204).send()
+  }
+)
+
 // Routes: Locations
 get(
   `${process.env.API_BASE}/locations`,
+  middleware.authenticate(),
   async (req, res) => {
-    const locations = await db.locations.list(req.query)
+    const locations = await db.locations.list(req.query, req.user)
     if (req.query.count === 'true') {
       const limit = req.query.limit ? parseInt(req.query.limit) : 1000
       let count = locations.length
@@ -158,8 +247,9 @@ get(
 )
 get(
   `${process.env.API_BASE}/locations/:id`,
+  middleware.authenticate(),
   async req => {
-    const location = await db.locations.show(req.params.id)
+    const location = await db.locations.show(req.params.id, req.user)
     if (req.query.embed) {
       const embedded = req.query.embed.split(',')
       if (embedded.includes('reviews')) {


### PR DESCRIPTION
Preview docs: https://petstore.swagger.io/?url=https://raw.githubusercontent.com/falling-fruit/api/location-lists/docs/openapi.yml

* Add, edit, delete, get (by list id, user id) location lists
* Locations are added to the end of the list. The legacy custom ordering of existing lists in `locations_routes.position` is maintained, but no endpoint is (yet?) provided to reorder locations.
* No endpoint is (yet?) provided to access location lists publicly. The legacy `routes.is_public` is ignored.
* `GET /locations` and `GET /locations/:id` now support authentication, in which case the former returns `in_list: boolean` for each location and the latter returns `lists` (array of Location Lists). I was worried the former would add a high overhead but I didn't notice any significant performance hit in my scant testing. But I have to wonder – does it make sense to return thousands of booleans when we could just have a small array of location ids?

Closes #8