### PR TITLE
Fix confirmation email URLs and wording (#75, #76)

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -573,7 +573,7 @@ _.send_password_reset = function(user, token) {
       <p style="color: #666;">If you're having trouble clicking the link above, copy and paste this URL into your browser:<br/>
       ${process.env.WEB_ORIGIN}/auth/password/edit?token=${token}
       </p>
-      <p>If you didn't request this, you can safely ignore this email. Your password won't change unless you visit the link above and create a new one.</p>
+      <p style="color: #666;">If you didn't request this, you can safely ignore this email. Your password won't change unless you visit the link above and create a new one.</p>
     `,
     tag: 'password-reset'
   }

--- a/helpers.js
+++ b/helpers.js
@@ -483,7 +483,6 @@ function send_email({to, subject, body, tag = null}) {
     Tag: tag
   })
 }
-
 _.send_email_confirmation = function(user, token) {
   const email = {
     to: user.email,
@@ -493,8 +492,10 @@ _.send_email_confirmation = function(user, token) {
     body: `
       <p>Welcome to Falling Fruit,</p>
       <p>To activate your account, you must confirm your email (${user.email}) by visiting the link below:
-      <br/>${process.env.WEB_ORIGIN}/auth/confirmation?token=${token}</p>
+      <br/><a href="${process.env.WEB_ORIGIN}/auth/confirmation?token=${token}">confirm</a></p>
       <p>Falling Fruit is powered by its users, so if you have the opportunity to add or improve it, please do so. Happy foraging!</p>
+      <hr/>
+      <p style="font-size: 12px; color: #666;">If you're having trouble clicking the link above, copy and paste this URL into your browser:<br/>${process.env.WEB_ORIGIN}/auth/confirmation?token=${token}</p>
     `,
     tag: 'email-confirmation'
   }
@@ -507,8 +508,9 @@ _.send_email_confirmation_exists = function(user) {
     subject: 'Registration attempt',
     body: `
       <p>Hello ${user.name || user.email},</p>
-      <p>Someone (maybe you) tried to sign up using this email (${user.email}). If this was you, sign in here instead:
-      <br/>${process.env.WEB_ORIGIN}/auth/sign_in</p>
+      <p>An account already exists for this email (${user.email}). If you forgot your password, reset it at <a href="${process.env.WEB_ORIGIN}/auth/password/new">here</a>.</p>
+      <p>Otherwise, you can sign in here instead:
+      <br/><a href="${process.env.WEB_ORIGIN}/auth/sign_in">sign in</a></p>
       <p>If you didn't request this, please ignore this email or contact us (info@fallingfruit.org) if you have questions.</p>
     `,
     tag: 'email-confirmation'

--- a/helpers.js
+++ b/helpers.js
@@ -491,11 +491,13 @@ _.send_email_confirmation = function(user, token) {
     // Phrase: users.mailer.confirmation_instructions_html
     body: `
       <p>Welcome to Falling Fruit,</p>
-      <p>To activate your account, you must confirm your email (${user.email}) by visiting the link below:
-      <br/><a href="${process.env.WEB_ORIGIN}/auth/confirmation?token=${token}">confirm</a></p>
+      <p>To activate your account, you must confirm your email (${user.email}) by clicking the link below:<br/>
+      <a href="${process.env.WEB_ORIGIN}/auth/confirmation?token=${token}">Confirm your email</a>
+      </p>
       <p>Falling Fruit is powered by its users, so if you have the opportunity to add or improve it, please do so. Happy foraging!</p>
       <hr/>
-      <p style="font-size: 12px; color: #666;">If you're having trouble clicking the link above, copy and paste this URL into your browser:<br/>${process.env.WEB_ORIGIN}/auth/confirmation?token=${token}</p>
+      <p style="color: #666;">If you're having trouble clicking the link above, copy and paste this URL into your browser:<br/>${process.env.WEB_ORIGIN}/auth/confirmation?token=${token}
+      </p>
     `,
     tag: 'email-confirmation'
   }
@@ -508,10 +510,14 @@ _.send_email_confirmation_exists = function(user) {
     subject: 'Registration attempt',
     body: `
       <p>Hello ${user.name || user.email},</p>
-      <p>An account already exists for this email (${user.email}). If you forgot your password, reset it at <a href="${process.env.WEB_ORIGIN}/auth/password/new">here</a>.</p>
-      <p>Otherwise, you can sign in here instead:
-      <br/><a href="${process.env.WEB_ORIGIN}/auth/sign_in">sign in</a></p>
-      <p>If you didn't request this, please ignore this email or contact us (info@fallingfruit.org) if you have questions.</p>
+      <p>Someone (possibly you) tried to sign up using this email (${user.email}). You already have an account, so you can sign in here instead:<br/>
+      ${process.env.WEB_ORIGIN}/auth/sign_in
+      </p>
+      <p>If you forgot your password, reset it here:<br/>
+      ${process.env.WEB_ORIGIN}/auth/password/new
+      </p>
+      <hr/>
+      <p style="color: #666;">If you didn't request this, you can safely ignore this email or reply with any questions.</p>
     `,
     tag: 'email-confirmation'
   }
@@ -524,9 +530,11 @@ _.send_email_confirmation_not_found = function(user) {
     subject: 'Email confirmation attempt',
     body: `
       <p>Hello,</p>
-      <p>Someone (possibly you) requested a link to confirm a Falling Fruit account. However, no account is associated with this email (${user.email}). If you made this request, please try again using a different email address:
-      <br/>${process.env.WEB_ORIGIN}/auth/confirmation/new</p>
-      <p>If you didn't request this, please ignore this email or contact us (info@fallingfruit.org) if you have questions.</p>
+      <p>Someone (possibly you) requested a link to confirm a Falling Fruit account. However, no account is associated with this email (${user.email}). If you made this request, please try again using a different email address:<br/>
+      ${process.env.WEB_ORIGIN}/auth/confirmation/new
+      </p>
+      <hr/>
+      <p style="color: #666;">If you didn't request this, you can safely ignore this email or reply with any questions.</p>
     `,
     tag: 'email-confirmation'
   }
@@ -539,9 +547,11 @@ _.send_email_confirmation_confirmed = function(user) {
     subject: 'Email already confirmed',
     body: `
       <p>Hello ${user.name || user.email},</p>
-      <p>Someone (most likely you) requested a link to confirm your email (${user.email}). Your email is already confirmed, so you can simply sign in here:
-      <br/>${process.env.WEB_ORIGIN}/auth/sign_in</p>
-      <p>If you didn't request this, please ignore this email or contact us (info@fallingfruit.org) if you have questions.</p>
+      <p>Someone (most likely you) requested a link to confirm your email (${user.email}). Your email is already confirmed, so you can simply sign in here:<br/>
+      ${process.env.WEB_ORIGIN}/auth/sign_in
+      </p>
+      <hr/>
+      <p style="color: #666;">If you didn't request this, you can safely ignore this email or reply with any questions.</p>
     `,
     tag: 'email-confirmation'
   }
@@ -556,9 +566,14 @@ _.send_password_reset = function(user, token) {
     // Phrase: users.mailer.reset_password_instructions_html
     body: `
       <p>Hello ${user.name || user.email},</p>
-      <p>Someone (most likely you) requested a link to change your password:
-      <br/>${process.env.WEB_ORIGIN}/auth/password/edit?token=${token}</p>
-      <p>If you didn't request this, you can ignore this email. Your password won't change unless you visit the link above and create a new one.</p>
+      <p>Someone (most likely you) requested a link to change your password:<br/>
+      <a href="${process.env.WEB_ORIGIN}/auth/password/edit?token=${token}">Change your password</a>
+      </p>
+      <hr/>
+      <p style="color: #666;">If you're having trouble clicking the link above, copy and paste this URL into your browser:<br/>
+      ${process.env.WEB_ORIGIN}/auth/password/edit?token=${token}
+      </p>
+      <p>If you didn't request this, you can safely ignore this email. Your password won't change unless you visit the link above and create a new one.</p>
     `,
     tag: 'password-reset'
   }
@@ -571,9 +586,11 @@ _.send_password_reset_not_found = function(user) {
     subject: 'Password reset attempt',
     body: `
       <p>Hello,</p>
-      <p>Someone (possibly you) requested a link to change the password for a Falling Fruit account. However, no account is associated with this email (${user.email}). If you made this request, please try again using a different email address:
-      <br/>${process.env.WEB_ORIGIN}/auth/password/new</p>
-      <p>If you didn't request this, please ignore this email or contact us (info@fallingfruit.org) if you have questions.</p>
+      <p>Someone (possibly you) requested a link to change the password for a Falling Fruit account. However, no account is associated with this email (${user.email}). If you made this request, please try again using a different email address:<br/>
+      ${process.env.WEB_ORIGIN}/auth/password/new
+      </p>
+      <hr/>
+      <p style="color: #666;">If you didn't request this, you can safely ignore this email or reply with any questions.</p>
     `,
     tag: 'password-reset'
   }


### PR DESCRIPTION
Closes #75
Closes #76

Revised the confirmation email to turn the raw token URL into a clickable "confirm" link, adding the full bare URL at the bottom as a backup text link. Also updated the account exists email wording to clearly state an account exists and provide direct clickable links for signing in and password resets.